### PR TITLE
#813 - Disable lint rule runtime/references for config.h

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -32,6 +32,7 @@ class Conf : public RdKafka::Conf {
   void listen();
   void stop();
 
+  // NOLINTNEXTLINE(runtime/references)
   void ConfigureCallback(const std::string &string_key, const v8::Local<v8::Function> &cb, bool add, std::string &errstr);
  protected:
   NodeKafka::Callbacks::Rebalance * m_rebalance_cb = NULL;


### PR DESCRIPTION
This pull request partially fixes this issue https://github.com/Blizzard/node-rdkafka/issues/813.